### PR TITLE
Replace uses of 'timer_reset' with an RCC reset; the former does not …

### DIFF
--- a/rtos/rtc/t.c
+++ b/rtos/rtc/t.c
@@ -1524,7 +1524,7 @@ setup(void) {
 		rcc_periph_clock_enable(RCC_AFIO);		// Need AFIO clock
 
 		timer_disable_counter(TIM2);			// Start timer
-		timer_reset(TIM2);				// Reset timer 2
+		rcc_periph_reset_pulse(RST_TIM2);				// Reset timer 2
 		timer_set_prescaler(TIM2,0);			// Clock counts every 13.9 ns
 
 		timer_set_mode(TIM2,TIM_CR1_CKD_CK_INT_MUL_4,

--- a/rtos/tim2_pwm/main.c
+++ b/rtos/tim2_pwm/main.c
@@ -41,7 +41,7 @@ task1(void *args __attribute__((unused))) {
 
 	// TIM2:
 	timer_disable_counter(TIM2);
-	timer_reset(TIM2);
+	rcc_periph_reset_pulse(RST_TIM2);
 
 	timer_set_mode(TIM2,
 		TIM_CR1_CKD_CK_INT,

--- a/rtos/tim2_pwm_pb3/main.c
+++ b/rtos/tim2_pwm_pb3/main.c
@@ -39,7 +39,7 @@ task1(void *args __attribute__((unused))) {
 
 	// TIM2:
 	timer_disable_counter(TIM2);
-	timer_reset(TIM2);
+	rcc_periph_reset_pulse(RST_TIM2);
 
 	timer_set_mode(TIM2,
 		TIM_CR1_CKD_CK_INT,

--- a/rtos/tim4_pwm_in/main.c
+++ b/rtos/tim4_pwm_in/main.c
@@ -49,7 +49,7 @@ task1(void *args __attribute__((unused))) {
 
 	// TIM4:
 	timer_disable_counter(TIM4);
-	timer_reset(TIM4);
+	rcc_periph_reset_pulse(RST_TIM4);
 	nvic_set_priority(NVIC_DMA1_CHANNEL3_IRQ,2);
 	nvic_enable_irq(NVIC_TIM4_IRQ);
 	timer_set_mode(TIM4,

--- a/rtos/timer1/main.c
+++ b/rtos/timer1/main.c
@@ -34,7 +34,7 @@ static void
 timer_setup(void) {
 
 	rcc_periph_clock_enable(RCC_TIM2);
-	timer_reset(TIM2);
+	rcc_periph_reset_pulse(RST_TIM2);
 	timer_set_mode(TIM2,TIM_CR1_CKD_CK_INT_MUL_4,TIM_CR1_CMS_EDGE,TIM_CR1_DIR_UP);
 	timer_set_prescaler(TIM2,360);		// Clock counts every 5 usec
 	timer_one_shot_mode(TIM2);

--- a/rtos/timer2/main.c
+++ b/rtos/timer2/main.c
@@ -44,7 +44,7 @@ timer_setup(void) {
 	rcc_periph_clock_enable(RCC_TIM2);		// Need TIM2 clock
 	rcc_periph_clock_enable(RCC_AFIO);		// Need AFIO clock
 
-	timer_reset(TIM2);				// Reset timer 2
+	rcc_periph_reset_pulse(RST_TIM2);				// Reset timer 2
 	timer_set_prescaler(TIM2,360);			// Clock counts every 5 usec
 	timer_set_mode(TIM2,TIM_CR1_CKD_CK_INT_MUL_4,
 		TIM_CR1_CMS_EDGE,TIM_CR1_DIR_UP);	// Set timer mode

--- a/rtos/ws2811/main.c
+++ b/rtos/ws2811/main.c
@@ -1524,7 +1524,7 @@ setup(void) {
 		rcc_periph_clock_enable(RCC_AFIO);		// Need AFIO clock
 
 		timer_disable_counter(TIM2);			// Start timer
-		timer_reset(TIM2);				// Reset timer 2
+		rcc_periph_reset_pulse(RST_TIM2);				// Reset timer 2
 		timer_set_prescaler(TIM2,0);			// Clock counts every 13.9 ns
 
 		timer_set_mode(TIM2,TIM_CR1_CKD_CK_INT_MUL_4,


### PR DESCRIPTION
…appear to exist in the most recent libopencm3.

I got build errors, and this seems to be the preferred solution:

https://github.com/libopencm3/libopencm3-examples/commit/1260b16772bcc7ce7e2c37f2419b33b58be297a8