### PR TITLE
Makefile.incl: use dependency files

### DIFF
--- a/Makefile.incl
+++ b/Makefile.incl
@@ -139,4 +139,6 @@ bigflash: $(BINARY).bin
 
 .PHONY: images clean elf bin hex srec list all
 
+-include $(OBJS:.o=.d)
+
 # End


### PR DESCRIPTION
The gcc -MD option is used in Makefile.incl,
but gcc generated dependency files are actually unused.

This commit fixes the fault.

Signed-off-by: Antony Pavlov <antonynpavlov@gmail.com>