### PR TITLE
Makefile: build only libopencm3_stm32f1.a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ clobber_libopencm3:
 libopencm3: libopencm3/lib/libopencm3_stm32f1.a
 
 libopencm3/lib/libopencm3_stm32f1.a:
-	$(MAKE) -C libopencm3
+	$(MAKE) -C libopencm3 TARGETS=stm32/f1
 
 libwwg:
 	$(MAKE) -C rtos/libwwg


### PR DESCRIPTION
By default libopencm3 Makefile builds the library for
all supported MCUs, e.g.:

    stm32f103c8t6$ make
    ...
    stm32f103c8t6$ find -iname '*.a'
    ./rtos/libwwg/libwwg.a
    ./libopencm3/lib/libopencm3_stm32f0.a
    ./libopencm3/lib/libopencm3_stm32l1.a
    ./libopencm3/lib/libopencm3_samd.a
    ./libopencm3/lib/libopencm3_sam3n.a
    ./libopencm3/lib/libopencm3_stm32l4.a
    ./libopencm3/lib/libopencm3_lpc13xx.a
    ./libopencm3/lib/libopencm3_stm32f7.a
    ./libopencm3/lib/libopencm3_efm32tg.a
    ./libopencm3/lib/libopencm3_efm32g.a
    ./libopencm3/lib/libopencm3_stm32f2.a
    ./libopencm3/lib/libopencm3_sam3s.a
    ./libopencm3/lib/libopencm3_lpc43xx.a
    ./libopencm3/lib/libopencm3_lm3s.a
    ./libopencm3/lib/libopencm3_lm4f.a
    ./libopencm3/lib/libopencm3_lpc43xx_m0.a
    ./libopencm3/lib/libopencm3_stm32f1.a
    ./libopencm3/lib/libopencm3_sam3u.a
    ./libopencm3/lib/libopencm3_lpc17xx.a
    ./libopencm3/lib/libopencm3_sam3a.a
    ./libopencm3/lib/libopencm3_efm32lg.a
    ./libopencm3/lib/libopencm3_vf6xx.a
    ./libopencm3/lib/libopencm3_stm32f3.a
    ./libopencm3/lib/libopencm3_sam3x.a
    ./libopencm3/lib/libopencm3_stm32l0.a
    ./libopencm3/lib/libopencm3_stm32f4.a
    ./libopencm3/lib/libopencm3_efm32gg.a
    stm32f103c8t6$

This patch forces libopencm3 build system to compile
the library only for STM32F1 MCU family, e.g.:

    stm32f103c8t6$ find -iname '*.a'
    ./rtos/libwwg/libwwg.a
    ./libopencm3/lib/libopencm3_stm32f1.a
    stm32f103c8t6$

Skipping unused libraries drastically reduces compilation time.

Signed-off-by: Antony Pavlov <antonynpavlov@gmail.com>