### PR TITLE
rtos: fix spelling mistake: "windbond" -> "winbond"

### DIFF
--- a/rtos/Makefile
+++ b/rtos/Makefile
@@ -3,7 +3,7 @@
 ######################################################################
 
 PROJS = blinky blinky2 timer1 timer2 uart uart2 uart3 usbcdc usbbulk i2c-pcf8574 \
-	windbond rtc rtc2
+	winbond rtc rtc2
 
 all:	libwwg 
 	for proj in $(PROJS) ; do \


### PR DESCRIPTION
The mistake causes this error message:

    stm32f103c8t6$ make
    ...
    make[2]: Entering directory 'stm32f103c8t6/rtos'
    make[2]: *** windbond: No such file or directory.  Stop.
    make[2]: Leaving directory 've3wwg_stm32f103c8t6/rtos'

Signed-off-by: Antony Pavlov <antonynpavlov@gmail.com>