### PR TITLE
Chapter 8. main.c: get_data8 should read and return exactly 1 byte (2 hex chars)

### DIFF
--- a/rtos/winbond/main.c
+++ b/rtos/winbond/main.c
@@ -366,7 +366,7 @@ get_data8(const char *prompt) {
 				continue;
 			}
 		}
-		if ( ++count > 2 )
+		if ( ++count >= 2 )
 			break;
 	}
 	if ( !count )


### PR DESCRIPTION
"off by one" error in the code for Chapter 8 (SPI Flash). get_data8 function in winbond/main.c  reads 3 chars, discards the first one and returns only the last two, causing wrong values to be written to the flash memory. I believe the same issue exists in get_data24 but it's not fixed in this pull request. 