### PR TITLE
Temperature calculation in Chap 14 (ADC)

### DIFF
--- a/rtos/adc/main.c
+++ b/rtos/adc/main.c
@@ -43,12 +43,12 @@ read_adc(uint8_t channel) {
  *********************************************************************/
 static int
 degrees_C100(void) {
-	static const int v25 = 143;
+	static const int v25 = 1365; // see https://github.com/ve3wwg/stm32f103c8t6/issues/11
 	int vtemp;
 
 	vtemp = (int)read_adc(ADC_CHANNEL_TEMP) * 3300 / 4095;
 
-	return (v25 - vtemp) / 45 + 2500; // temp = (1.43 - Vtemp) / 4.5 + 25.00
+	return (v25 - vtemp) * 1000 / 45 + 2500; // temp = (1.43 - Vtemp) / 4.5 + 25.00
 }
 
 /*********************************************************************


### PR DESCRIPTION
I am a bit confused by the temp calculation used in the code:

1. `v25 = 143`,  so it is in cV (centi volt, 0.01V); vtemp is in mV (0.001V), because we use 3300 instead of 3.3 in the calculation of  vtemp (`vtemp = (int)read_adc(ADC_CHANNEL_TEMP) * 3300 / 4095;`). It seems that the expression `v25 - vtemp` has terms of different factors of V. 

2. Avg_Slope (=4.5 in the table 14-2) is given in mV/˚C, so assuming that `v25-vtemp` is in mV,  then  `(v25-vtemp)/Avg_Slope` is in ˚C, and we can simply add 25˚C to get the final temperature.

I've changed `temp100` to reflect the changes above, while staying with the ints only and returning temp*100:

<pre>
static int
degrees_C100(void) {
	static const int v25 = <b>1430</b>;
	int vtemp;
	
	vtemp = (int)read_adc(ADC_CHANNEL_TEMP) * 3300 / 4095;
	
	return (v25 - vtemp)<b>*1000</b> / 45 + 2500; 
}
</pre>

The good news is that I can see the temp raising by 5˚C when I turn the board on from a cold start, the bad news is that the temp is off by ~14 ˚C, i.e. I am seeing 40˚C, when it should be 26˚C. The offset error  is within the bounds given in the reference manual, but it still looks suspicious.


