### PR TITLE
Chap. 16 and 17 (Timers). Args for timer_set_prescaler and timer_set_period are off by one

### DIFF
--- a/rtos/tim2_pwm/main.c
+++ b/rtos/tim2_pwm/main.c
@@ -47,7 +47,7 @@ task1(void *args __attribute__((unused))) {
 		TIM_CR1_CKD_CK_INT,
 		TIM_CR1_CMS_EDGE,
 		TIM_CR1_DIR_UP);
-	timer_set_prescaler(TIM2,72-1);
+	timer_set_prescaler(TIM2,72-1); //see https://github.com/ve3wwg/stm32f103c8t6/pull/12/
 	// Only needed for advanced timers:
 	// timer_set_repetition_counter(TIM2,0);
 	timer_enable_preload(TIM2);

--- a/rtos/tim2_pwm/main.c
+++ b/rtos/tim2_pwm/main.c
@@ -47,12 +47,12 @@ task1(void *args __attribute__((unused))) {
 		TIM_CR1_CKD_CK_INT,
 		TIM_CR1_CMS_EDGE,
 		TIM_CR1_DIR_UP);
-	timer_set_prescaler(TIM2,72);
+	timer_set_prescaler(TIM2,72-1);
 	// Only needed for advanced timers:
 	// timer_set_repetition_counter(TIM2,0);
 	timer_enable_preload(TIM2);
 	timer_continuous_mode(TIM2);
-	timer_set_period(TIM2,33333);
+	timer_set_period(TIM2,33333-1);
 
 	timer_disable_oc_output(TIM2,TIM_OC2);
 	timer_set_oc_mode(TIM2,TIM_OC2,TIM_OCM_PWM1);

--- a/rtos/tim2_pwm_pb3/main.c
+++ b/rtos/tim2_pwm_pb3/main.c
@@ -45,12 +45,12 @@ task1(void *args __attribute__((unused))) {
 		TIM_CR1_CKD_CK_INT,
 		TIM_CR1_CMS_EDGE,
 		TIM_CR1_DIR_UP);
-	timer_set_prescaler(TIM2,36000000*2/150/50);
+	timer_set_prescaler(TIM2,36000000*2/150/50-1);
 	// Only needed for advanced timers:
 	// timer_set_repetition_counter(TIM2,0);
 	timer_enable_preload(TIM2);
 	timer_continuous_mode(TIM2);
-	timer_set_period(TIM2,50);
+	timer_set_period(TIM2,50-1);
 
 	timer_disable_oc_output(TIM2,TIM_OC2);
 	timer_set_oc_mode(TIM2,TIM_OC2,TIM_OCM_PWM1);

--- a/rtos/tim4_pwm_in/main.c
+++ b/rtos/tim4_pwm_in/main.c
@@ -56,7 +56,7 @@ task1(void *args __attribute__((unused))) {
 		TIM_CR1_CKD_CK_INT,
 		TIM_CR1_CMS_EDGE,
 		TIM_CR1_DIR_UP);
-	timer_set_prescaler(TIM4,72);
+	timer_set_prescaler(TIM4,72-1);
 	timer_ic_set_input(TIM4,TIM_IC1,TIM_IC_IN_TI1);
 	timer_ic_set_input(TIM4,TIM_IC2,TIM_IC_IN_TI1);
 	timer_ic_set_filter(TIM4,TIM_IC_IN_TI1,TIM_IC_CK_INT_N_2);


### PR DESCRIPTION

According to [libopencm3   #655](https://github.com/libopencm3/libopencm3/issues/655), both `timer_set_prescaler` and `timer_set_period`  take `0` as a valid argument and thus we should subtract `1` when supplying absolute values for the prescaler and the period. 

With this change, I was able to get exactly 30Hz for the first demo and 150Hz for the second as specified in the code (Chap. 16). Duty cycles also have correct timings (verified with a logic analyzer). 

For Chap. 17, when I connect servo output with 30Hz from the first demo of Chap. 16, I get:

<pre>
cc1if=33332 (1087522), cc2if=2499 (1087522)
cc1if=33332 (1087552), cc2if=1199 (1087552)
cc1if=33332 (1087582), cc2if=499 (1087582)
cc1if=33332 (1087612), cc2if=1199 (1087612)
cc1if=33332 (1087642), cc2if=2499 (1087642)
cc1if=33332 (1087672), cc2if=1199 (1087672)
cc1if=33332 (1087702), cc2if=499 (1087702)
cc1if=33332 (1087732), cc2if=1199 (1087732)
cc1if=33332 (1087762), cc2if=2499 (1087762)
cc1if=33332 (1087792), cc2if=1199 (1087792)
cc1if=33332 (1087822), cc2if=499 (1087822)
cc1if=33332 (1087852), cc2if=1199 (1087852)
cc1if=33332 (1087882), cc2if=2499 (1087882)
cc1if=33332 (1087912), cc2if=1199 (1087912)
cc1if=33332 (1087942), cc2if=499 (1087942)
cc1if=33332 (1087972), cc2if=1199 (1087972)
cc1if=33332 (1088002), cc2if=2499 (1088002)
cc1if=33332 (1088032), cc2if=1199 (1088032)
cc1if=33332 (1088062), cc2if=499 (1088062)
cc1if=33332 (1088092), cc2if=1199 (1088092)
cc1if=33332 (1088122), cc2if=2499 (1088122)
</pre>

So it seems that `cc2if` and `cc2if` require "+1 rule", probably because the counts start with `0`. If we do that we get period = 33333, hence frequency 30Hz as expected (`1/(33333/10^6)`) and the duty cycle timings are 2.5ms, 1.2ms and 0.5ms as specified in the code.

Notes:

1. Interestingly enough "-1 rule" does not apply to `timer_set_oc_value`, so no changes are needed for that function.

2. For the center-aligned mode, for instance
<pre>
timer_set_mode(TIM2,
		TIM_CR1_CKD_CK_INT,
		<b>TIM_CR1_CMS_CENTER_1</b>, 
		TIM_CR1_DIR_UP);
</pre>
 The argument of`timer_set_period` should be +1 as compared to the case of `TIM_CR1_CMS_EDGE `. This is probably because two periods overlap when the counter goes from up- to down- count. With this setting, I was able to get exactly 75Hz freq for the second demo of Chap 16. This mode is not covered in the book, so it's just a curious fact.

Small unrelated typo? `nvic_set_priority(NVIC_DMA1_CHANNEL3_IRQ,2);` In listing 17-1 on page 307 is confusing. The line is also present in the source code at tim4_pwm_in/main.c:54. Is it needed?




