### PR TITLE
Fix system clock setup in blinky example

### DIFF
--- a/rtos/blinky/main.c
+++ b/rtos/blinky/main.c
@@ -33,7 +33,7 @@ task1(void *args) {
 int
 main(void) {
 
-	rcc_clock_setup_in_hse_16mhz_out_72mhz();	// Use this for "blue pill"
+	rcc_clock_setup_in_hse_8mhz_out_72mhz();	// Use this for "blue pill"
 	rcc_periph_clock_enable(RCC_GPIOC);
 	gpio_set_mode(GPIOC,GPIO_MODE_OUTPUT_2_MHZ,GPIO_CNF_OUTPUT_PUSHPULL,GPIO13);
 


### PR DESCRIPTION
Call `rcc_clock_setup_in_hse_8mhz_out_72mhz` rather than `rcc_clock_setup_in_hse_16mhz_out_72mhz` as the blue pill has an 8MHz external clock.