### PR TITLE
Fix ve3wwg/stlink submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 
 [submodule "stlink"]
 	path = stlink
-	url = https@github.com:ve3wwg/stlink.git
+	url = https://github.com/ve3wwg/stlink.git


### PR DESCRIPTION
Hi @ve3wwg - thanks for writing the "Beginning STM32" book, I'm working through it now for a second time and there's so much to learn!

I've spotted a mistake in the submodule URL and would like to contribute a fix please.

Are we meant to include the _ve3wwg/stlink_ as a submodule? The book says to install it through Homebrew.

Here's the error I got before I patched it:
```bash
$ git submodule update
Cloning into '~/stm32f103c8t6/libopencm3'...
Cloning into '~/stm32f103c8t6/stlink'...
https@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'https@github.com:ve3wwg/stlink.git' into submodule path '~/stm32f103c8t6/stlink' failed
Failed to clone 'stlink'. Retry scheduled
Cloning into '~/stm32f103c8t6/stlink'...
https@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'https@github.com:ve3wwg/stlink.git' into submodule path '~/stm32f103c8t6/stlink' failed
Failed to clone 'stlink' a second time, aborting
```